### PR TITLE
[FEATURE UPDATES] Skip Painted Pixels, Outline First, Upgrades First

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Changelog v4.2.5 (UNOFFICIAL)
+- Added "Outline Before Drawing" Mode (great to reserve your drawing space)
+- Added "Skip Painted Pixels" Mode, making drawing "behind" other's artwork possible
+- Gently reworked wait time logic when no accounts are ready to paint.  Instead of refreshing every X seconds, it'll now wait until the next available account will be ready before rechecking. (Reduces calls to wplace.live)
+- Moved upgrade logic to happen BEFORE painting, so that if the account is at max charges, free extra charges are received by upgrading those first.
+
 ## Changelog v4.2.5 QUICK FIX
 - Fixed extension!
 - Added automatic Cloudflare Turnstile solving!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Changelog v4.2.6-4.2.7
+- Added an "Active/Expired accounts" table shown after the status check (you can remove non‑working accounts with one click).
+- Added an extension that automates account re‑login. See the AutoLogin README: [WPlace AutoLogin — Chrome Extension](https://github.com/lllexxa/wplacer/blob/main/Wplacer-AutoLogin-Profiles/README.md)
+
+
 ## Changelog v4.2.5 QUICK FIX
 - Fixed extension!
 - Added automatic Cloudflare Turnstile solving!

--- a/public/index.html
+++ b/public/index.html
@@ -331,6 +331,22 @@
                                     <span class="slider"></span>
                                 </label>
                             </div>
+							
+							<div class="setting-toggle"> <!-- Sei -->
+                                <label for="skipPaintedPixels" class="label-margin0">Skip painted pixels</label>
+                                <label class="switch" class="label-margin0">
+                                    <input id="skipPaintedPixels" name="skipPaintedPixels" type="checkbox" />
+                                    <span class="slider"></span>
+                                </label>
+                            </div>
+							
+							<div class="setting-toggle"> <!-- Sei -->
+                                <label for="outlineMode" class="label-margin0">Outline-First Mode</label>
+                                <label class="switch" class="label-margin0">
+                                    <input id="outlineMode" name="outlineMode" type="checkbox" />
+                                    <span class="slider"></span>
+                                </label>
+                            </div>
 
                             <div class="setting-toggle">
                                 <label for="antiGriefMode" class="label-margin0">Enable Anti-Grief mode</label>

--- a/public/scripts/index.js
+++ b/public/scripts/index.js
@@ -40,6 +40,8 @@ const canBuyMaxCharges = $("canBuyMaxCharges");
 const canBuyCharges = $("canBuyCharges");
 const autoBuyNeededColors = $("autoBuyNeededColors");
 const antiGriefMode = $("antiGriefMode");
+const skipPaintedPixels = $("skipPaintedPixels"); // Sei
+const outlineMode = $("outlineMode"); // Sei
 const paintTransparent = $("paintTransparent");
 const heatmapEnabled = $("heatmapEnabled");
 const heatmapLimit = $("heatmapLimit");
@@ -1633,6 +1635,8 @@ templateForm.addEventListener('submit', async (e) => {
         canBuyMaxCharges: canBuyMaxCharges.checked,
         autoBuyNeededColors: !!autoBuyNeededColors?.checked && !!(usePaidColors?.checked),
         antiGriefMode: antiGriefMode.checked,
+		skipPaintedPixels: !!skipPaintedPixels.checked, // Sei
+		outlineMode: !!outlineMode.checked, // Sei
         paintTransparentPixels: !!paintTransparent.checked,
         heatmapEnabled: !!(heatmapEnabled && heatmapEnabled.checked),
         heatmapLimit: Math.max(1, Math.floor(Number(heatmapLimit && heatmapLimit.value ? heatmapLimit.value : 10000)))
@@ -2686,6 +2690,8 @@ openManageTemplates.addEventListener("click", () => {
                 if (t.autoBuyNeededColors) enabled.push('Buy premium colors');
                 if (t.paintTransparentPixels) enabled.push('Paint transparent pixels');
                 if (t.antiGriefMode) enabled.push('Anti‑grief mode');
+				if (t.skipPaintedPixels) enabled.push('Skip painted pixels'); // Sei
+				if (t.outlineMode) enabled.push('Outline first'); // Sei
                 const enabledLine = enabled.length ? `<div><span class="t-templates-enabled">Enabled:</span> ${enabled.join(', ')}</div>` : '';
 
                 meta.innerHTML = `
@@ -2789,6 +2795,8 @@ openManageTemplates.addEventListener("click", () => {
                     canBuyMaxCharges.checked = T.canBuyMaxCharges;
                     if (autoBuyNeededColors) autoBuyNeededColors.checked = !!T.autoBuyNeededColors;
                     antiGriefMode.checked = T.antiGriefMode;
+					skipPaintedPixels.checked = t.skipPaintedPixels; // Sei
+					outlineMode.checked = t.outlineMode; // Sei
                     paintTransparent.checked = !!T.paintTransparentPixels;
                     if (typeof T.heatmapEnabled !== 'undefined' && heatmapEnabled) heatmapEnabled.checked = !!T.heatmapEnabled;
                     if (heatmapLimitWrap) heatmapLimitWrap.style.display = heatmapEnabled && heatmapEnabled.checked ? '' : 'none';
@@ -3292,6 +3300,8 @@ async function refreshActiveBar() {
                 canBuyCharges.checked = T.canBuyCharges;
                 canBuyMaxCharges.checked = T.canBuyMaxCharges;
                 antiGriefMode.checked = T.antiGriefMode;
+                skipPaintedPixels.checked = !!t.skipPaintedPixels; // Sei
+                outlineMode.checked = !!t.outlineMode; // Sei
                 paintTransparent.checked = !!T.paintTransparentPixels;
                 if (typeof T.heatmapEnabled !== 'undefined' && heatmapEnabled) heatmapEnabled.checked = !!T.heatmapEnabled;
                 if (heatmapLimitWrap) heatmapLimitWrap.style.display = heatmapEnabled && heatmapEnabled.checked ? '' : 'none';


### PR DESCRIPTION
In this Pull Request:

• I ported over "Skip Painted Pixels" and "Outline First" modes from the original wplacer script.  These modes were incredibly helpful for drawing behind other's artwork, as well as reserving your space with outlining your graphic first.

• I moved handling upgrades up to happen before painting, so you can potentially benefit from the free charges if your charges are currently maxed.

• I freed up console logs a bit by only refreshing when necessary.  The script now looks for which account will be ready next, and when they're ready, *then* it rechecks.  Seems way better than refreshing every 30 seconds...
`[9/11/2025, 2:41:55 PM] (wplacer#SYSTEM) [Testing] ⏳ No users ready. Waiting for next available user (UserName): 19m.`

- - - - -
### NOTE
In my modifications, around line 2040, I added some logic to prevent the endless refresh-bomb that I'd occasionally face when painting a mixed-premium color graphic with multiple accounts, where only 1 had premium colors with "buy premium colors" being disabled.  When all normal colors were already in place, and it was a non-premium account's turn to draw, it would constantly re-check for mismatched pixels, causing rate limited errors.  For now, I just added some sleep.  Proper checks should be done to fix this bug.

### ENHANCEMENT REQUEST
With the latest update, the chrome extension no longer seems to wait for the client to request a refresh, and instead seems to refresh constantly every 45 seconds.  This is incredibly annoying when manually drawing, and I fear it creates many unnecessary requests to wplace.  There must be a better way than to refresh so often when bots won't even be ready to draw anytime soon?

- - - - -
I would personally love to see more controls and drawing methods ported from other pixel based scripts that exist out there.  Specifically, methods that make the drawing feel more human to any spectators.  Thank you Lllexxa.  You're a true dev and a hero for keeping this project alive!  I am always very excited to see new updates and features and am looking forward to seeing what's next!

_P.S.  I am new to github and probably did this all wrong.  Please pardon while I learn myself around!  I also commented `// Sei`  on every line I modified, so if I did anything redundant, it can be quickly found and fixed. Preferably, the comments would be removed on the main branch._