### PR TITLE
Fix: ensure all templates run at startup if autoStart is enabled

### DIFF
--- a/server.js
+++ b/server.js
@@ -4668,7 +4668,7 @@ app.get('/export-tokens', (req, res) => {
       for (const [id, template] of Object.entries(templates)) {
         if (template.autoStart && !template.running) {
           try {
-            await template.start();
+            Promise.resolve().then(() => template.start()).catch(err => console.error(`❌ Failed to auto-start template \"${template?.name || 'unknown'}\"`, err));
             autoStartedCount++;
             console.log(`🚀 Auto-started template: ${template.name}`);
           } catch (error) {


### PR DESCRIPTION
Before:
Only the first autoStart template was executed at startup because the loop used await template.start(), which is a long running loop, it blocked the others.

After:
Changed logic to fire-and-forget each template.start(). All templates with autoStart=true now launch concurrently.